### PR TITLE
Socket Timeout 구현

### DIFF
--- a/config/default.config
+++ b/config/default.config
@@ -36,6 +36,8 @@ server {
 
 	autoindex off
 	client_body_limit 256 
+	recv_timeout 6;
+	send_timeout 6;
 
 	location /board {
 		allow_methods GET DELETE

--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -3,6 +3,7 @@
 
 #include <sys/socket.h>
 #include <netdb.h>
+#include <sys/time.h>
 #include "Server.hpp"
 
 class Client

--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -10,6 +10,7 @@ class Client
 private:
 	int socket;
 	int received_size;
+	timeval last_get_time;
 	
 public:
 	socklen_t address_length;
@@ -22,8 +23,10 @@ public:
 	
 	int get_socket() const;
 	int get_received_size() const;
+	timeval get_last_time() const;
 	void set_socket(int value);
 	void set_received_size(int size);
+	void set_last_time_sec(timeval& tv);
 
 	std::string get_root_path(std::string path);
 	

--- a/includes/Request.hpp
+++ b/includes/Request.hpp
@@ -13,6 +13,7 @@ public:
 	std::string path;
 	std::map<std::string, std::string> headers;
 	std::string body;
+	size_t	content_length;
 	Request(int client_fd);
 	~Request();
 
@@ -25,7 +26,7 @@ public:
 		out << "method: " << req.method << "\npath: " << req.path << "\nheaders: "
 		<< req.headers << "\nbody: " << req.body << "\n";
 		return out;
-}
+	}
 };
 
 

--- a/includes/ServerManager.hpp
+++ b/includes/ServerManager.hpp
@@ -37,6 +37,7 @@ public:
 	void treat_request();
 	void send_error_page(int code, Client &Client);
 	bool is_response_timeout(Client& Client);
+	bool handle_CGI(Request *request, Location *loc);
 
 	void get_method(Client &client, std::string path);
 	void post_method(Client &client, Request &request);

--- a/includes/ServerManager.hpp
+++ b/includes/ServerManager.hpp
@@ -36,6 +36,7 @@ public:
 
 	void treat_request();
 	void send_error_page(int code, Client &Client);
+	bool is_response_timeout(Client& Client);
 
 	void get_method(Client &client, std::string path);
 	void post_method(Client &client, Request &request);

--- a/includes/ServerManager.hpp
+++ b/includes/ServerManager.hpp
@@ -17,6 +17,7 @@ private:
 	std::vector<Client> clients;
 	int max_fd;
 	fd_set reads;
+	timeval timeout;
 
 	std::map<int, std::string> status_info;
 

--- a/includes/ServerManager.hpp
+++ b/includes/ServerManager.hpp
@@ -17,7 +17,6 @@ private:
 	std::vector<Client> clients;
 	int max_fd;
 	fd_set reads;
-	timeval timeout;
 
 	std::map<int, std::string> status_info;
 

--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -5,6 +5,9 @@ Client::Client(Server *server)
 	this->server = server;
 	address_length = sizeof(struct sockaddr_storage);
 	received_size = 0;
+	timeval tv;
+	memset(&tv, 0, sizeof(tv));
+	last_get_time = tv;
 	memset(request, 0, MAX_REQUEST_SIZE + 1);
 }
 
@@ -21,6 +24,16 @@ int Client::get_received_size() const
 {
 	return received_size;
 }
+
+timeval Client::get_last_time() const
+{
+	return last_get_time;
+};
+
+void Client::set_last_time_sec(timeval& tv)
+{
+	last_get_time = tv;	
+};
 
 void Client::set_socket(int value)
 {

--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -5,9 +5,7 @@ Client::Client(Server *server)
 	this->server = server;
 	address_length = sizeof(struct sockaddr_storage);
 	received_size = 0;
-	timeval tv;
-	memset(&tv, 0, sizeof(tv));
-	last_get_time = tv;
+	gettimeofday(&last_get_time, NULL);
 	memset(request, 0, MAX_REQUEST_SIZE + 1);
 }
 

--- a/srcs/ConfigParser.cpp
+++ b/srcs/ConfigParser.cpp
@@ -173,6 +173,12 @@ int ConfigParser::set_server_values(Server *server, const std::string key, const
 	{
 		server->client_body_limit = atoi(value.c_str());
 	}
+	else if (key == "recv_timeout") {
+		server->recv_timeout.tv_sec = atoi(value.c_str());
+	}
+	else if (key == "send_timeout") {
+		server->send_timeout.tv_sec = atoi(value.c_str());
+	}
 	else if (key == "return")
 	{
 		std::vector<std::string> tmp = split(value, ' ');

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -5,10 +5,10 @@ Server::Server(/* args */)
 	client_body_limit = 1024;
 
 	struct timeval tv;
-	tv.tv_sec = 0;
-	tv.tv_usec = 100000;
-	recv_timeout = tv;
-	send_timeout = tv;
+	tv.tv_sec = 60;
+	tv.tv_usec = 0;
+	if (recv_timeout.tv_sec != 0) recv_timeout = tv;
+	if (send_timeout.tv_sec != 0) send_timeout = tv;
 	
 	autoindex = true;
 	host = "";

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -112,7 +112,7 @@ void ServerManager::wait_on_clients()
 		FD_SET(clients[i].get_socket(), &reads);
 		if (clients[i].get_socket() > max)
 			max = clients[i].get_socket();
-	};
+	}
 	if (select(max + 1, &reads, 0, 0, 0) < 0)
 	{
 		fprintf(stderr, "[ERROR] select() failed. (%d)\n", errno);

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -119,7 +119,6 @@ void ServerManager::wait_on_clients()
 		exit(1);
 	}
 	this->reads = reads;
-	}
 }
 
 void ServerManager::drop_client(Client client)
@@ -166,7 +165,6 @@ void ServerManager::treat_request()
 				send_error_page(400, clients[i]);
 				continue;
 			}
-			
 			int r = recv(clients[i].get_socket(), 
 					clients[i].request + clients[i].get_received_size(), 
 					MAX_REQUEST_SIZE - clients[i].get_received_size(), 0);
@@ -195,7 +193,12 @@ void ServerManager::treat_request()
 					return ;
 				}
 				// body size 검사 해야함
-				if (req.method == "GET")
+				// 클라이언트 바디 리미트 넘어가면 413번 넘어가야함
+				// Content_length 체크해서.
+
+				if (is_response_timeout(clients[i]) == false)
+					send_error_page(408, clients[i]);
+				else if (req.method == "GET")
 					get_method(clients[i], req.path);
 				else if (req.method == "POST")
 					post_method(clients[i], req);
@@ -207,6 +210,15 @@ void ServerManager::treat_request()
 			}
 		}
 	}
+}
+
+bool ServerManager::is_response_timeout(Client& client) {
+	static timeval tv;
+	
+	gettimeofday(&tv, NULL);
+	if (tv.tv_sec - client.get_last_time().tv_sec > client.server->recv_timeout.tv_sec) return false;
+	client.set_last_time_sec(tv);
+	return true;
 }
 
 void ServerManager::send_error_page(int code, Client &client)

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -195,7 +195,6 @@ void ServerManager::treat_request()
 				// body size 검사 해야함
 				// 클라이언트 바디 리미트 넘어가면 413번 넘어가야함
 				// Content_length 체크해서.
-
 				if (is_response_timeout(clients[i]) == true)
 					send_error_page(408, clients[i]);
 				else if (req.method == "GET")
@@ -211,6 +210,11 @@ void ServerManager::treat_request()
 		}
 	}
 }
+
+bool ServerManager::is_payload_too_long(Client& client) {
+	return (client.get_received_size() > client.server.) ? true : false;
+}
+
 
 bool ServerManager::is_response_timeout(Client& client) {
 	static timeval tv;

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -3,6 +3,8 @@
 ServerManager::ServerManager(std::vector<Server> servers)
 {
 	this->servers = servers;
+	this->timeout.tv_sec = 60;
+	this->timeout.tv_usec = 0;
 
 	status_info.insert(std::make_pair(200, "200 OK"));
 	status_info.insert(std::make_pair(201, "201 Created"));
@@ -95,6 +97,7 @@ void ServerManager::wait_on_clients()
 	int max = -1;
 	int recv;
 	fd_set reads;
+	timeval time;
 
 	FD_ZERO(&reads);
 	for (int i = 0; i < servers.size(); i++)
@@ -114,22 +117,30 @@ void ServerManager::wait_on_clients()
 			max = clients[i].get_socket();
 	}
 	// timeout tv 설정 이후 select의 5번째 매개변수로 설정
-	// 타임아웃시 0리턴
+	// timeout 체크에 쓰이는 timeval 객체의 갱신을 위해 select을 반복문으로 감쌈.
 	// ? : server 마다 timeout 시간이 다를 수 있나?
 	// ! : 만약 다를 수 있다면, 어떻게 개별적으로 servers[i]의 listen_socker[i]에 대한 timeout 상황을 측정하나?
-	recv = select(max + 1, &reads, 0, 0, 0);
-	if (recv < 0)
-	{
-		fprintf(stderr, "[ERROR] select() failed. (%d)\n", errno);
-		exit(1);
+	while (1) {
+		time.tv_sec = this->timeout.tv_sec;
+		time.tv_usec = this->timeout.tv_usec;
+		recv = select(max + 1, &reads, 0, 0, &time);
+		if (recv < 0)
+		{
+			fprintf(stderr, "[ERROR] select() failed. (%d)\n", errno);
+			exit(1);
+		}
+		if (recv == 0)
+		{
+			fprintf(stderr, "[ERROR] timeout. (%d)\n", errno);
+			continue;
+		}
+		//변화가 생긴 소켓
+		this->reads = reads;
+		// 여기 안에서 this->reads에 reads 건네어 주고,
+		// this->accept() && treat_request() 를 실행하면 괜찮지 않을까... 싶은데.
+		// 분리한 특별한 이유가 있는지 팀원들에게 물어보자.
 	}
-	if (recv == 0)
-	{
-		fprintf(stderr, "[ERROR] timeout. (%d)\n", errno);
-		exit(1);
-	}
-    //변화가 생긴 소켓
-	this->reads = reads;
+
 }
 
 void ServerManager::drop_client(Client client)

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -196,7 +196,7 @@ void ServerManager::treat_request()
 				// 클라이언트 바디 리미트 넘어가면 413번 넘어가야함
 				// Content_length 체크해서.
 
-				if (is_response_timeout(clients[i]) == false)
+				if (is_response_timeout(clients[i]) == true)
 					send_error_page(408, clients[i]);
 				else if (req.method == "GET")
 					get_method(clients[i], req.path);
@@ -216,9 +216,9 @@ bool ServerManager::is_response_timeout(Client& client) {
 	static timeval tv;
 	
 	gettimeofday(&tv, NULL);
-	if (tv.tv_sec - client.get_last_time().tv_sec > client.server->recv_timeout.tv_sec) return false;
+	if (tv.tv_sec - client.get_last_time().tv_sec > client.server->recv_timeout.tv_sec) return true;
 	client.set_last_time_sec(tv);
-	return true;
+	return false;
 }
 
 void ServerManager::send_error_page(int code, Client &client)

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -213,11 +213,6 @@ void ServerManager::treat_request()
 	}
 }
 
-bool ServerManager::is_payload_too_long(Client& client) {
-	return (client.get_received_size() > client.server.) ? true : false;
-}
-
-
 bool ServerManager::is_response_timeout(Client& client) {
 	static timeval tv;
 	


### PR DESCRIPTION
- 클라이언트 객체 초기 생성시 지역변수 timeval에 현재 시간을 저장하도록 함.
- 응답 처리시 is_response_timeout 으로 체크
- (현재시간 - 클라이언트가 마지막으로 응답받은 시간 > 설정한 timeout 시간) 을 sec단위로 비교하고 참이면 408 에러메세지 응답
- 이후 cgi 처리 구현완료 이후 cgi timeout 도 여기서 처리 