### PR TITLE
Response 객체의 멤버함수 수정

### DIFF
--- a/includes/Response.hpp
+++ b/includes/Response.hpp
@@ -7,7 +7,8 @@
 class Response
 {
 private:
-	std::string status;
+	std::string status_number;
+	std::string status_phrase;
 	std::map<std::string, std::string> headers;
 	std::string body;
 
@@ -20,9 +21,8 @@ public:
 	void append_header(std::string first, std::string second);
 	int get_body_size();
 
-	void make_error_body();
-	void make_redirection_body();
-	void make_redirection_body(std::string url);
+	void make_status_body();
+	void make_status_body(std::string url);
 	std::string make_header();
 	std::string serialize();
 };

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -2,7 +2,8 @@
 
 Response::Response(std::string status)
 {
-	this->status = status;
+	this->status_number = status.substr(0, 3);
+	this->status_phrase = status.substr(4, status.size());
 }
 
 Response::~Response()
@@ -23,7 +24,7 @@ std::string Response::make_header()
 {
 	std::string result;
 
-	result.append("HTTP/1.1 " + status + "\r\n");
+	result.append("HTTP/1.1 " + status_number + "\r\n");
 	for (std::map<std::string, std::string>::iterator i = headers.begin(); i != headers.end(); i++)
 	{
 		result.append((*i).first + ": " + (*i).second + "\r\n");	
@@ -33,14 +34,14 @@ std::string Response::make_header()
 	return result;
 }
 
-void Response::make_error_body()
+void Response::make_status_body()
 {
 	std::string result;
 
 	result.append("<!DOCTYPE html><html><head><meta charset=\"UTF-8\"/><title>webserv</title></head>");
 	result.append("<body>");
-	result.append("<h1>" + status.substr(0, 3) + "</h1>");
-	result.append("<h3>" + status.substr(4, status.size()) + "</h3>");
+	result.append("<h1>" + status_number + "</h1>");
+	result.append("<h3>" + status_phrase + "</h3>");
 	result.append("<p>Click <a href=\"/\">here</a> to return home.</p>");
 	result.append("</body></html>");
 	
@@ -48,22 +49,7 @@ void Response::make_error_body()
 	body = result;
 }
 
-void Response::make_redirection_body()
-{
-	std::string result;
-
-	result.append("<!DOCTYPE html><html><head><meta charset=\"UTF-8\"/><title>webserv</title></head>");
-	result.append("<body>");
-	result.append("<h1>" + status.substr(0, 3) + "</h1>");
-	result.append("<h3>" + status.substr(4, status.size()) + "</h3>");
-	result.append("<p>Click <a href=\"/\">here</a> to return home.</p>");
-	result.append("</body></html>");
-
-	body.clear();
-	body = result;
-}
-
-void Response::make_redirection_body(std::string url)
+void Response::make_status_body(std::string url)
 {
 	std::string result;
 
@@ -77,7 +63,7 @@ std::string Response::serialize()
 {
 	std::string result;
 
-	result.append("HTTP/1.1 " + status + "\r\n");
+	result.append("HTTP/1.1 " + status_number + "\r\n");
 	for (std::map<std::string, std::string>::iterator i = headers.begin(); i != headers.end(); i++)
 	{
 		result.append((*i).first + ": " + (*i).second + "\r\n");	

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -266,9 +266,9 @@ void ServerManager::send_redirection(Client &client, std::string request_method)
 	std::cout << ">> send redirection response" << std::endl;
 	Response response(status_info[client.server->redirect_status]);
 	if (client.server->redirect_status == 300)
-		response.make_redirection_body(client.server->redirect_url);
+		response.make_status_body(client.server->redirect_url);
 	else
-		response.make_redirection_body();
+		response.make_status_body();
 	response.append_header("Server", client.server->server_name);
 	response.append_header("Date", get_current_date_GMT());
 	response.append_header("Content-Type", "text/html");
@@ -285,7 +285,7 @@ void ServerManager::send_error_page(int code, Client &client)
 {
 	std::cout << ">> send error page" << std::endl;
 	Response response(status_info[code]);
-	response.make_error_body();
+	response.make_status_body();
 	response.append_header("Connection", "close");
 	response.append_header("Content-Length", std::to_string(response.get_body_size()));
 	response.append_header("Content-Type", "text/html");
@@ -299,7 +299,7 @@ void ServerManager::send_405_error_page(int code, Client &client, std::vector<Me
 	std::cout << ">> send error page" << std::endl;
 	std::string allowed_method_list;
 	Response response(status_info[code]);
-	response.make_error_body();
+	response.make_status_body();
 	response.append_header("Connection", "close");
 	response.append_header("Content-Length", std::to_string(response.get_body_size()));
 	response.append_header("Content-Type", "text/html");


### PR DESCRIPTION
- make_error_body 와 make_redirection_body 를 통합했습니다.
- 300 번 응답을 위해 make_status_body(std::string url)로 시그니처만 다른 걸 만들어주었습니다.
- 상태넘버가 분리가 안되는 걸 해결하기 위해 status_number와 status_phrase를 따로 멤버변수로 했습니다.