### PR TITLE
handle 403, 404 status code

### DIFF
--- a/includes/ServerManager.hpp
+++ b/includes/ServerManager.hpp
@@ -5,6 +5,7 @@
 #include <sys/time.h>
 #include <dirent.h>
 #include <cstdio>
+#include <sys/stat.h>
 #include "Client.hpp"
 #include "Request.hpp"
 #include "Response.hpp"


### PR DESCRIPTION
GET 메소드에서
- 특정 파일을 지정해서 접근했을 때 파일이 없으면 404 Not found 반환
- server 블록에서 autoindex 설정이 off일 경우 index directive에 명시한 파일이 존재하지 않으면 403 Forbidden 반환
- location 블록에서 index directive가 없거나 index directive에 명시한 파일이 존재하지 않는 경우 404 Not found 반환