### PR TITLE
error_page 기능 추가

### DIFF
--- a/config/default.config
+++ b/config/default.config
@@ -9,6 +9,9 @@ server {
 	autoindex on;
 	client_body_limit 256;
 
+	error_page 404 405 ./www/html/error/error.html;
+	error_page 500 ./www/html/error/error2.html;
+
 	location /board {
 		allow_methods GET;
 		root ./www/html;

--- a/includes/Response.hpp
+++ b/includes/Response.hpp
@@ -8,13 +8,13 @@ class Response
 {
 private:
 	std::map<std::string, std::string> headers;
-	std::string body;
 
 	Response();
 
 public:
 	std::string status_code;
 	std::string status_phrase;
+	std::string body;
 	Response(std::string status);
 	~Response();
 

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -17,6 +17,7 @@ public:
 	std::vector<std::string> index;
 	std::vector<MethodType> allow_methods;
 	std::vector<Location> locations;
+	std::map<int, std::string> error_pages;
 	
 	int redirect_status;
 	std::string redirect_url;

--- a/includes/ServerManager.hpp
+++ b/includes/ServerManager.hpp
@@ -6,6 +6,7 @@
 #include <dirent.h>
 #include <cstdio>
 #include <sys/stat.h>
+#include <fstream>
 #include "Client.hpp"
 #include "Request.hpp"
 #include "Response.hpp"
@@ -38,8 +39,7 @@ public:
 	void print_servers_info();
 
 private:
-	void send_error_page(int code, Client &Client);
-	void send_405_error_page(int code, Client &Client, std::vector<MethodType> allow_methods);
+	void send_error_page(int code, Client &Client, std::vector<MethodType> *allow_methods);
 	void send_redirection(Client &client, std::string request_method);
 	int	is_allowed_method(std::vector<MethodType> allow_methods, std::string method);
 	std::string methodtype_to_s(MethodType method);

--- a/srcs/ConfigParser.cpp
+++ b/srcs/ConfigParser.cpp
@@ -195,6 +195,18 @@ int ConfigParser::set_server_values(Server *server, const std::string key, const
 		server->redirect_status = atoi(tmp[0].c_str());
 		server->redirect_url = tmp[1];
 	}
+	else if (key == "error_page")
+	{
+		std::vector<std::string> tmp = split(value, ' ');
+		std::string path = tmp[tmp.size() - 1];
+		for (int i = 0; i != tmp.size() - 1; i++)
+		{
+			int status_code = atoi(tmp[i].c_str());
+			if (server->error_pages.find(status_code) != server->error_pages.end())
+				continue;
+			server->error_pages.insert(std::make_pair(status_code, path));
+		}
+	}
 	else
 	{
 		return FAILED;

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -52,6 +52,10 @@ int Request::parsing(std::string request)
 			break;
 		i = end + 2;
 	}
+	if (headers["Host"] == "")
+		return 400;
+	if (headers["Expectation"] != "")
+		return 417;
 	return 0;
 }
 

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -54,7 +54,7 @@ int Request::parsing(std::string request)
 	}
 	if (headers["Host"] == "")
 		return 400;
-	if (headers["Expectation"] != "")
+	if (headers["Expect"] != "")
 		return 417;
 	return 0;
 }

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -34,8 +34,7 @@ ServerManager::ServerManager(std::vector<Server> servers)
 		for (it = servers[i].error_pages.begin(); it != servers[i].error_pages.end(); it++)
 		{
 			int status_code = it->first;
-			if (status_code < 400 || (status_code > 431 && status_code < 500) 
-				|| status_code > 511 || status_info.find(status_code) == status_info.end())
+			if (status_code < 400 || (status_code > 431 && status_code < 500) || status_code > 511)
 			{
 				fprintf(stderr, "[ERROR] invalid status code on error_page\n");
 				exit(1);

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -21,6 +21,7 @@ ServerManager::ServerManager(std::vector<Server> servers)
 	status_info.insert(std::make_pair(411, "411 Length Required"));
 	status_info.insert(std::make_pair(413, "413 Request Entity Too Large"));
 	status_info.insert(std::make_pair(414, "414 URI Too Long"));
+	status_info.insert(std::make_pair(417, "417 Expectation Failed"));
 	status_info.insert(std::make_pair(429, "429 Too Many Request"));
 	status_info.insert(std::make_pair(500, "500 Internal Server Error"));
 	status_info.insert(std::make_pair(502, "502 Bad Gateway"));

--- a/www/html/error/error.html
+++ b/www/html/error/error.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Error</title>
+</head>
+<body>
+	<h1>Error!</h1>
+</body>
+</html>

--- a/www/html/error/error2.html
+++ b/www/html/error/error2.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Error</title>
+</head>
+<body>
+	<h1>Internal Error!</h1>
+</body>
+</html>


### PR DESCRIPTION
configuration 파일의 server 블록 안에서 `error_page code code ... code path;` 형태로 설정합니다.
1. code는 status code로 400, 500번대이어야 인지, 실제 존재하는 status code인지 확인하고 아니면 프로그램을 종료합니다.
2. path가 잘못되었다면 어떤 에러로 인해 발생해도 404 Not found를 반환하게 됩니다.
3. 하나의 status code에 대해 error_page를 두 번 이상 세팅했다면 첫번째 세팅한 에러 페이지가 에러 상황 시 반환됩니다.

추가로 요청을 보낼 때 Host가 헤더에 없으면 400 Bad Request가 나타나는 현상을 발견해서 코드에 추가했습니다.
Expect 헤더를 지원하지 않으면 417을 반환하면 된다고 해서 Expect 헤더가 있을 시 417 Expectation Failed를 반환하도록 했습니다.

그리고 ServerManager의 send_error_page 메소드와 send_405_error_page 메소드를 하나로 합쳤습니다.