### PR TITLE
411 에러 고치고 502 에러 추가

### DIFF
--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -105,8 +105,6 @@ int Request::parsing(std::string request)
 	}
 	if (headers["Host"] == "")
 		return 400;
-	if (headers["Expect"] != "")
-		return 417;
 	return 0;
 }
 

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -410,7 +410,7 @@ void ServerManager::post_method(Client &client, Request &request)
 {
 	std::cout << "POST method\n";
 
-	if (request.headers["Transfer-Encoding"] != "chunked" && rrequest.headers.find("Content-Length") == request.headers.end())
+	if (request.headers["Transfer-Encoding"] != "chunked" && request.headers.find("Content-Length") == request.headers.end())
 	{
 		send_error_page(411, client);
 		return;
@@ -775,7 +775,10 @@ int ServerManager::send_cgi_response(Client& client, CgiHandler& ch, Request& re
 	{
 		if (req.method == "GET")
 		{
-			Response res(status_info[atoi(get_status_cgi(cgi_ret).c_str())]);
+			std::string code = get_status_cgi(cgi_ret);
+			if (code.empty())
+				return 502;
+			Response res(status_info[atoi(code.c_str())]);
 			handle_cgi_GET_response(res, cgi_ret, client);
 			std::string result = res.serialize();
 			int send_ret = send(client.get_socket(), result.c_str(), result.size(), 0);
@@ -788,7 +791,10 @@ int ServerManager::send_cgi_response(Client& client, CgiHandler& ch, Request& re
 		}
 		if (req.method == "POST")
 		{
-			Response res(status_info[atoi(get_status_cgi(cgi_ret).c_str())]);
+			std::string code = get_status_cgi(cgi_ret);
+			if (code.empty())
+				return 502;
+			Response res(status_info[atoi(code.c_str())]);
 			handle_cgi_POST_response(res, cgi_ret, client, req);
 			std::string result = res.serialize();
 			int send_ret = send(client.get_socket(), result.c_str(), result.size(), 0);

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -411,7 +411,7 @@ void ServerManager::post_method(Client &client, Request &request)
 {
 	std::cout << "POST method\n";
 
-	if (request.headers.find("Content-Length") == request.headers.end())
+	if (request.headers["Transfer-Encoding"] != "chunked" && rrequest.headers.find("Content-Length") == request.headers.end())
 	{
 		send_error_page(411, client);
 		return;

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -21,7 +21,6 @@ ServerManager::ServerManager(std::vector<Server> servers)
 	status_info.insert(std::make_pair(411, "411 Length Required"));
 	status_info.insert(std::make_pair(413, "413 Request Entity Too Large"));
 	status_info.insert(std::make_pair(414, "414 URI Too Long"));
-	status_info.insert(std::make_pair(417, "417 Expectation Failed"));
 	status_info.insert(std::make_pair(429, "429 Too Many Request"));
 	status_info.insert(std::make_pair(500, "500 Internal Server Error"));
 	status_info.insert(std::make_pair(502, "502 Bad Gateway"));

--- a/srcs/ServerManagerHelper.cpp
+++ b/srcs/ServerManagerHelper.cpp
@@ -142,7 +142,14 @@ std::string ServerManager::get_status_cgi(std::string& cgi_ret)
 	std::string status_line;
 	std::stringstream ss(cgi_ret);
 
-	getline(ss, status_line, '\n');
+	std::string line;
+	while (getline(ss, line, '\n'))
+	{
+		if (line.substr(0, 6) == "Status")
+			status_line = line;
+	}
+	if (status_line.empty())
+		return status_line;
 	cgi_ret.erase(0, status_line.length() + 1);
 	status_line.erase(0, 8);
 	status_line.erase(status_line.length() - 1, 1);


### PR DESCRIPTION
- POST 메소드 chunked request 시 411 에러 나타나는 현상 수정하였습니다
- CGI result에서 status code 찾는 부분 조금 수정하였습니다.
- CGI result에서 적절한 status code 반환하지 않을 시 502 에러 반환하도록 추가하였습니다.