### PR TITLE
remove unnecessary lines

### DIFF
--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -13,18 +13,14 @@ ServerManager::ServerManager(std::vector<Server> servers)
 	status_info.insert(std::make_pair(303, "303 See Other"));
 	status_info.insert(std::make_pair(307, "307 Temporary Redirect"));
 	status_info.insert(std::make_pair(400, "400 Bad Request"));
-	status_info.insert(std::make_pair(401, "401 Unauthorized"));
-	status_info.insert(std::make_pair(403, "403 Forbidden"));
 	status_info.insert(std::make_pair(404, "404 Not found"));
 	status_info.insert(std::make_pair(405, "405 Method Not Allowed"));
 	status_info.insert(std::make_pair(408, "408 Request Timeout"));
 	status_info.insert(std::make_pair(411, "411 Length Required"));
 	status_info.insert(std::make_pair(413, "413 Request Entity Too Large"));
 	status_info.insert(std::make_pair(414, "414 URI Too Long"));
-	status_info.insert(std::make_pair(429, "429 Too Many Request"));
 	status_info.insert(std::make_pair(500, "500 Internal Server Error"));
 	status_info.insert(std::make_pair(502, "502 Bad Gateway"));
-	status_info.insert(std::make_pair(504, "504 Gateway Timeout"));
 	status_info.insert(std::make_pair(505, "505 HTTP Version Not Supported"));
 
 	max_fd = -1;
@@ -95,16 +91,6 @@ void ServerManager::run_selectPoll(fd_set *reads, fd_set *writes)
 	if ((ret = select(this->max_fd + 1, reads, writes, 0, 0)) < 0)
 	{
 		fprintf(stderr, "[ERROR] select() failed. (%d)\n", errno);
-		if (errno == EINVAL)
-		{
-			for (unsigned long i = 0; i < clients.size(); i++)
-				send_error_page(429, clients[i], NULL);
-		}
-		else 
-		{
-			for (unsigned long i = 0; i < clients.size(); i++)
-				send_error_page(500, clients[i], NULL);
-		}
 		exit(1);
 	}
 	else if (ret == 0)

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -89,10 +89,7 @@ void ServerManager::run_selectPoll(fd_set *reads, fd_set *writes)
 	int ret = 0;
 
 	if ((ret = select(this->max_fd + 1, reads, writes, 0, 0)) < 0)
-	{
-		fprintf(stderr, "[ERROR] select() failed. (%d)\n", errno);
 		exit(1);
-	}
 	else if (ret == 0)
 		std::cout << "[ERROR] select() timeout.\n";
 	this->reads = *reads;


### PR DESCRIPTION
- 429 에러는 Therefore, servers are not required to use the 429 status code; when limiting resource usage, it may be more appropriate to just drop connections, or take other steps. 라는 문장에 따라 없어도 될 것 같습니다.
- select 시 에러가 나면 accept 전이기 때문에 어차피 send를 할 수 없어서 에러 페이지 보내는 부분을 없앴습니다.
- 사용하지 않는 status code를 지웠습니다.
